### PR TITLE
fix: replace println with eprintln in all MCP server examples for stdio transport compliance

### DIFF
--- a/src/examples/example_01_hello_world.rs
+++ b/src/examples/example_01_hello_world.rs
@@ -152,11 +152,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging to help with debugging
     tracing_subscriber::fmt::init();
 
-    println!("🚀 Starting Hello World MCP Server");
-    println!("📝 Available tools: greeting");
-    println!("💡 Send JSON-RPC messages via stdin");
-    println!("📋 Example: {{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}}");
-    println!();
+    eprintln!("🚀 Starting Hello World MCP Server");
+    eprintln!("📝 Available tools: greeting");
+    eprintln!("💡 Send JSON-RPC messages via stdin");
+    eprintln!("📋 Example: {{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}}");
+    eprintln!();
 
     // Create our server handler instance
     let server = HelloWorldServer::new();
@@ -204,6 +204,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("👋 Hello World server shutting down");
+    eprintln!("👋 Hello World server shutting down");
     Ok(())
 }

--- a/src/examples/example_02_calculator.rs
+++ b/src/examples/example_02_calculator.rs
@@ -204,11 +204,11 @@ impl CalculatorServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("🧮 Starting Calculator MCP Server");
-    println!("📝 Available tools: calculator");
-    println!("💡 Send JSON-RPC messages via stdin");
-    println!("📋 Example: {{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{{\"name\":\"calculator\",\"arguments\":{{\"operation\":\"add\",\"a\":5,\"b\":3}}}}}}");
-    println!();
+    eprintln!("🧮 Starting Calculator MCP Server");
+    eprintln!("📝 Available tools: calculator");
+    eprintln!("💡 Send JSON-RPC messages via stdin");
+    eprintln!("📋 Example: {{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{{\"name\":\"calculator\",\"arguments\":{{\"operation\":\"add\",\"a\":5,\"b\":3}}}}}}");
+    eprintln!();
 
     let server = CalculatorServer::new();
 
@@ -254,7 +254,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("🧮 Calculator server shutting down");
+    eprintln!("🧮 Calculator server shutting down");
     Ok(())
 }
 

--- a/src/examples/example_03_text_processor.rs
+++ b/src/examples/example_03_text_processor.rs
@@ -164,15 +164,15 @@ impl TextProcessorServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("📝 Starting Text Processor MCP Server");
-    println!("🛠️  Available tools: transform_text, analyze_text");
-    println!("💡 Send JSON-RPC messages via stdin");
+    eprintln!("📝 Starting Text Processor MCP Server");
+    eprintln!("🛠️  Available tools: transform_text, analyze_text");
+    eprintln!("💡 Send JSON-RPC messages via stdin");
 
     // Simple demo mode for testing
     let server = TextProcessorServer::new();
 
     // Demo usage
-    println!("\n🧪 Running demo transformations:");
+    eprintln!("\n🧪 Running demo transformations:");
 
     let demo_text = "hello world";
     let transform_args = serde_json::json!({
@@ -183,12 +183,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("transform_text", transform_args) {
         Ok(result) => {
             let response: TextResponse = serde_json::from_value(result).unwrap();
-            println!(
+            eprintln!(
                 "✅ Transform '{}' to uppercase: '{}'",
                 demo_text, response.result
             );
         }
-        Err(e) => println!("❌ Transform failed: {}", e),
+        Err(e) => eprintln!("❌ Transform failed: {}", e),
     }
 
     let analyze_args = serde_json::json!({
@@ -198,15 +198,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("analyze_text", analyze_args) {
         Ok(result) => {
             let response: TextAnalysisResponse = serde_json::from_value(result).unwrap();
-            println!(
+            eprintln!(
                 "✅ Analysis of '{}': {} words, {} chars",
                 demo_text, response.word_count, response.character_count
             );
         }
-        Err(e) => println!("❌ Analysis failed: {}", e),
+        Err(e) => eprintln!("❌ Analysis failed: {}", e),
     }
 
-    println!("\n🎉 Text processor demo completed");
+    eprintln!("\n🎉 Text processor demo completed");
     Ok(())
 }
 

--- a/src/examples/example_04_simple_client.rs
+++ b/src/examples/example_04_simple_client.rs
@@ -44,19 +44,19 @@ impl SimpleMcpClient {
 
     // Simulate connecting to an MCP server
     pub async fn connect(&self) -> Result<(), String> {
-        println!("🔗 Connecting to MCP server: {}", self.server_url);
+        eprintln!("🔗 Connecting to MCP server: {}", self.server_url);
 
         // In a real implementation, this would establish a connection
         // For this demo, we'll just simulate success
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        println!("✅ Connected successfully!");
+        eprintln!("✅ Connected successfully!");
         Ok(())
     }
 
     // Simulate listing available tools from the server
     pub async fn list_tools(&self) -> Result<Vec<ToolInfo>, String> {
-        println!("🔍 Discovering available tools...");
+        eprintln!("🔍 Discovering available tools...");
 
         // Simulate network delay
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -101,9 +101,9 @@ impl SimpleMcpClient {
             },
         ];
 
-        println!("📋 Found {} tools", tools.len());
+        eprintln!("📋 Found {} tools", tools.len());
         for tool in &tools {
-            println!("  - {}: {}", tool.name, tool.description);
+            eprintln!("  - {}: {}", tool.name, tool.description);
         }
 
         Ok(tools)
@@ -111,7 +111,7 @@ impl SimpleMcpClient {
 
     // Simulate calling a tool on the server
     pub async fn call_tool(&self, request: ToolCallRequest) -> Result<ToolCallResponse, String> {
-        println!("🔧 Calling tool: {}", request.tool_name);
+        eprintln!("🔧 Calling tool: {}", request.tool_name);
 
         // Simulate network delay
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -216,8 +216,8 @@ impl SimpleMcpClient {
 
     // Demonstrate a complete client workflow
     pub async fn demonstrate_client_workflow(&self) -> Result<(), String> {
-        println!("🚀 Starting MCP Client Demonstration");
-        println!("====================================");
+        eprintln!("🚀 Starting MCP Client Demonstration");
+        eprintln!("====================================");
 
         // Step 1: Connect to server
         self.connect().await?;
@@ -226,7 +226,7 @@ impl SimpleMcpClient {
         let tools = self.list_tools().await?;
 
         // Step 3: Call each tool with sample data
-        println!("\n🧪 Testing tools with sample data:");
+        eprintln!("\n🧪 Testing tools with sample data:");
 
         // Test greeting tool
         if tools.iter().any(|t| t.name == "greeting") {
@@ -241,16 +241,16 @@ impl SimpleMcpClient {
                     result: Some(result),
                     ..
                 } => {
-                    println!("✅ Greeting result: {}", result);
+                    eprintln!("✅ Greeting result: {}", result);
                 }
                 ToolCallResponse {
                     success: false,
                     error: Some(err),
                     ..
                 } => {
-                    println!("❌ Greeting failed: {}", err);
+                    eprintln!("❌ Greeting failed: {}", err);
                 }
-                _ => println!("⚠️  Unexpected greeting response"),
+                _ => eprintln!("⚠️  Unexpected greeting response"),
             }
         }
 
@@ -271,16 +271,16 @@ impl SimpleMcpClient {
                     result: Some(result),
                     ..
                 } => {
-                    println!("✅ Calculator result: {}", result);
+                    eprintln!("✅ Calculator result: {}", result);
                 }
                 ToolCallResponse {
                     success: false,
                     error: Some(err),
                     ..
                 } => {
-                    println!("❌ Calculator failed: {}", err);
+                    eprintln!("❌ Calculator failed: {}", err);
                 }
-                _ => println!("⚠️  Unexpected calculator response"),
+                _ => eprintln!("⚠️  Unexpected calculator response"),
             }
         }
 
@@ -300,20 +300,20 @@ impl SimpleMcpClient {
                     result: Some(result),
                     ..
                 } => {
-                    println!("✅ Text transform result: {}", result);
+                    eprintln!("✅ Text transform result: {}", result);
                 }
                 ToolCallResponse {
                     success: false,
                     error: Some(err),
                     ..
                 } => {
-                    println!("❌ Text transform failed: {}", err);
+                    eprintln!("❌ Text transform failed: {}", err);
                 }
-                _ => println!("⚠️  Unexpected text transform response"),
+                _ => eprintln!("⚠️  Unexpected text transform response"),
             }
         }
 
-        println!("\n🎉 Client demonstration completed successfully!");
+        eprintln!("\n🎉 Client demonstration completed successfully!");
         Ok(())
     }
 }

--- a/src/examples/example_05_resource_provider.rs
+++ b/src/examples/example_05_resource_provider.rs
@@ -301,20 +301,20 @@ impl ResourceProviderServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("📚 Starting Resource Provider MCP Server");
-    println!("🗂️  Sample documents with search capabilities loaded");
-    println!();
+    eprintln!("📚 Starting Resource Provider MCP Server");
+    eprintln!("🗂️  Sample documents with search capabilities loaded");
+    eprintln!();
 
     let server = ResourceProviderServer::new();
 
     // Demonstrate resource functionality
-    println!("🧪 Demonstrating resource functionality:");
+    eprintln!("🧪 Demonstrating resource functionality:");
 
     // List resources
     let resources = server.list_resources();
-    println!("📋 Available resources ({} total):", resources.len());
+    eprintln!("📋 Available resources ({} total):", resources.len());
     for resource in &resources {
-        println!(
+        eprintln!(
             "  - {} ({})",
             resource.uri,
             resource.name.as_deref().unwrap_or("Unnamed")
@@ -322,7 +322,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Demonstrate search functionality
-    println!("\n🔍 Search demonstration:");
+    eprintln!("\n🔍 Search demonstration:");
     let search_args = serde_json::json!({
         "query": "Rust",
         "limit": 3
@@ -331,22 +331,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("search_documents", search_args) {
         Ok(result) => {
             let response: SearchResponse = serde_json::from_value(result).unwrap();
-            println!(
+            eprintln!(
                 "✅ Found {} documents matching 'Rust':",
                 response.total_count
             );
             for doc in response.matches {
-                println!("  - {}: {} [{}]", doc.id, doc.title, doc.tags.join(", "));
+                eprintln!("  - {}: {} [{}]", doc.id, doc.title, doc.tags.join(", "));
             }
         }
-        Err(e) => println!("❌ Search failed: {}", e),
+        Err(e) => eprintln!("❌ Search failed: {}", e),
     }
 
     // Demonstrate resource reading
-    println!("\n📖 Resource reading demonstration:");
+    eprintln!("\n📖 Resource reading demonstration:");
     match server.read_resource("document://doc1") {
         Ok(content) => {
-            println!("✅ Successfully read document://doc1");
+            eprintln!("✅ Successfully read document://doc1");
             let text = content
                 .get("contents")
                 .and_then(|c| c.as_array())
@@ -354,15 +354,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|item| item.get("text"))
                 .and_then(|t| t.as_str())
                 .unwrap_or("No content");
-            println!(
+            eprintln!(
                 "📄 Content preview: {}...",
                 &text[..std::cmp::min(text.len(), 100)]
             );
         }
-        Err(e) => println!("❌ Read failed: {}", e),
+        Err(e) => eprintln!("❌ Read failed: {}", e),
     }
 
-    println!("\n🎉 Resource provider demonstration completed!");
+    eprintln!("\n🎉 Resource provider demonstration completed!");
     Ok(())
 }
 

--- a/src/examples/example_06_configurable_server.rs
+++ b/src/examples/example_06_configurable_server.rs
@@ -133,7 +133,7 @@ impl ConfigurableServer {
             if let Ok(config_content) = std::fs::read_to_string(&config_path) {
                 if let Ok(file_config) = serde_json::from_str::<ServerConfig>(&config_content) {
                     config = file_config;
-                    println!("📋 Loaded configuration from: {}", config_path);
+                    eprintln!("📋 Loaded configuration from: {}", config_path);
                 }
             }
         }
@@ -171,11 +171,11 @@ impl ConfigurableServer {
             }
         }
 
-        println!("⚙️  Configuration loaded:");
-        println!("   Server: {} v{}", config.server_name, config.version);
-        println!("   Max connections: {}", config.max_connections);
-        println!("   Timeout: {}s", config.timeout_seconds);
-        println!("   Features: {:?}", config.enabled_features);
+        eprintln!("⚙️  Configuration loaded:");
+        eprintln!("   Server: {} v{}", config.server_name, config.version);
+        eprintln!("   Max connections: {}", config.max_connections);
+        eprintln!("   Timeout: {}s", config.timeout_seconds);
+        eprintln!("   Features: {:?}", config.enabled_features);
 
         Ok(config)
     }
@@ -341,8 +341,8 @@ impl ConfigurableServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("⚙️  Starting Configurable MCP Server");
-    println!("=====================================");
+    eprintln!("⚙️  Starting Configurable MCP Server");
+    eprintln!("=====================================");
 
     // Load configuration from multiple sources
     let config = ConfigurableServer::load_config()?;
@@ -351,17 +351,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = ConfigurableServer::new(config);
 
     // Demo configuration features
-    println!("\n🧪 Configuration Demo:");
+    eprintln!("\n🧪 Configuration Demo:");
 
     // List enabled tools
     let tools = server.list_tools();
-    println!("📋 Enabled tools ({}):", tools.len());
+    eprintln!("📋 Enabled tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Test greeting in different languages
-    println!("\n🌍 Multi-language greeting test:");
+    eprintln!("\n🌍 Multi-language greeting test:");
     for (lang, name) in [
         ("en", "Developer"),
         ("es", "Desarrollador"),
@@ -373,45 +373,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
         match server.call_tool("greeting", args) {
-            Ok(result) => println!(
+            Ok(result) => eprintln!(
                 "  ✅ {}: {}",
                 lang,
                 result.get("message").unwrap_or(&Value::Null)
             ),
-            Err(e) => println!("  ❌ {}: {}", lang, e),
+            Err(e) => eprintln!("  ❌ {}: {}", lang, e),
         }
     }
 
     // Test echo with configured prefix
-    println!("\n📢 Echo test:");
+    eprintln!("\n📢 Echo test:");
     let echo_args = serde_json::json!({
         "message": "Configuration is working!"
     });
 
     match server.call_tool("echo", echo_args) {
-        Ok(result) => println!("  ✅ {}", result.get("echo").unwrap_or(&Value::Null)),
-        Err(e) => println!("  ❌ {}", e),
+        Ok(result) => eprintln!("  ✅ {}", result.get("echo").unwrap_or(&Value::Null)),
+        Err(e) => eprintln!("  ❌ {}", e),
     }
 
     // Test status
-    println!("\n📊 Server status:");
+    eprintln!("\n📊 Server status:");
     match server.call_tool("status", serde_json::json!({})) {
         Ok(result) => {
             if let Ok(status) = serde_json::from_value::<StatusResponse>(result) {
-                println!("  ✅ Server: {} v{}", status.server_name, status.version);
-                println!("  ⏱️  Uptime: {}s", status.uptime_seconds);
-                println!("  📊 Requests: {}", status.total_requests);
-                println!("  🔧 Features: {:?}", status.enabled_features);
+                eprintln!("  ✅ Server: {} v{}", status.server_name, status.version);
+                eprintln!("  ⏱️  Uptime: {}s", status.uptime_seconds);
+                eprintln!("  📊 Requests: {}", status.total_requests);
+                eprintln!("  🔧 Features: {:?}", status.enabled_features);
             }
         }
-        Err(e) => println!("  ❌ Status error: {}", e),
+        Err(e) => eprintln!("  ❌ Status error: {}", e),
     }
 
-    println!("\n🎉 Configuration demo completed!");
-    println!("\n💡 Try setting environment variables:");
-    println!("   export MCP_SERVER_NAME=\"My Custom Server\"");
-    println!("   export MCP_MAX_CONNECTIONS=50");
-    println!("   cargo run --bin example_06_configurable_server");
+    eprintln!("\n🎉 Configuration demo completed!");
+    eprintln!("\n💡 Try setting environment variables:");
+    eprintln!("   export MCP_SERVER_NAME=\"My Custom Server\"");
+    eprintln!("   export MCP_MAX_CONNECTIONS=50");
+    eprintln!("   cargo run --bin example_06_configurable_server");
 
     Ok(())
 }

--- a/src/examples/example_07_file_operations.rs
+++ b/src/examples/example_07_file_operations.rs
@@ -501,17 +501,17 @@ impl FileOperationsServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("📁 Starting File Operations MCP Server");
-    println!("=====================================");
+    eprintln!("📁 Starting File Operations MCP Server");
+    eprintln!("=====================================");
 
     // Create config with safe defaults
     let config = FileOperationsConfig::default();
 
-    println!("⚙️  Security Configuration:");
-    println!("   Read-only mode: {}", config.read_only_mode);
-    println!("   Max file size: {} bytes", config.max_file_size);
-    println!("   Allowed extensions: {:?}", config.allowed_extensions);
-    println!("   Allowed directories: {:?}", config.allowed_directories);
+    eprintln!("⚙️  Security Configuration:");
+    eprintln!("   Read-only mode: {}", config.read_only_mode);
+    eprintln!("   Max file size: {} bytes", config.max_file_size);
+    eprintln!("   Allowed extensions: {:?}", config.allowed_extensions);
+    eprintln!("   Allowed directories: {:?}", config.allowed_directories);
 
     // Create server
     let server = FileOperationsServer::new(config);
@@ -527,17 +527,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = async_fs::write("./temp/config.json", r#"{"demo": true, "version": "1.0"}"#).await;
 
     // Demo file operations
-    println!("\n🧪 File Operations Demo:");
+    eprintln!("\n🧪 File Operations Demo:");
 
     // List tools
     let tools = server.list_tools();
-    println!("📋 Available tools ({}):", tools.len());
+    eprintln!("📋 Available tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Test read file
-    println!("\n📖 Reading demo file:");
+    eprintln!("\n📖 Reading demo file:");
     let read_args = serde_json::json!({
         "file_path": "./temp/demo.txt"
     });
@@ -545,21 +545,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("read_file", read_args).await {
         Ok(result) => {
             let content = result.get("content").unwrap_or(&Value::Null);
-            println!(
+            eprintln!(
                 "  ✅ Content: {}",
                 content.as_str().unwrap_or("").lines().next().unwrap_or("")
             );
-            println!(
+            eprintln!(
                 "     Size: {} bytes",
                 result.get("size").unwrap_or(&Value::Null)
             );
         }
-        Err(e) => println!("  ❌ Read failed: {}", e),
+        Err(e) => eprintln!("  ❌ Read failed: {}", e),
     }
 
     // Test list directory
     if server.config.enable_directory_listing {
-        println!("\n📂 Listing temp directory:");
+        eprintln!("\n📂 Listing temp directory:");
         let list_args = serde_json::json!({
             "directory_path": "./temp"
         });
@@ -567,21 +567,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         match server.call_tool("list_directory", list_args).await {
             Ok(result) => {
                 if let Ok(listing) = serde_json::from_value::<DirectoryListing>(result) {
-                    println!("  ✅ Found {} items:", listing.total_count);
+                    eprintln!("  ✅ Found {} items:", listing.total_count);
                     for file in listing.files {
-                        println!(
+                        eprintln!(
                             "    - {}: {} ({} bytes)",
                             file.name, file.file_type, file.size
                         );
                     }
                 }
             }
-            Err(e) => println!("  ❌ List failed: {}", e),
+            Err(e) => eprintln!("  ❌ List failed: {}", e),
         }
     }
 
     // Test get file info
-    println!("\n📊 Getting file info:");
+    eprintln!("\n📊 Getting file info:");
     let info_args = serde_json::json!({
         "file_path": "./temp/demo.txt"
     });
@@ -589,22 +589,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("get_file_info", info_args).await {
         Ok(result) => {
             if let Ok(info) = serde_json::from_value::<FileInfo>(result) {
-                println!("  ✅ File: {}", info.name);
-                println!("     Type: {}", info.file_type);
-                println!("     Size: {} bytes", info.size);
-                println!("     Modified: {}", info.modified);
+                eprintln!("  ✅ File: {}", info.name);
+                eprintln!("     Type: {}", info.file_type);
+                eprintln!("     Size: {} bytes", info.size);
+                eprintln!("     Modified: {}", info.modified);
             }
         }
-        Err(e) => println!("  ❌ Info failed: {}", e),
+        Err(e) => eprintln!("  ❌ Info failed: {}", e),
     }
 
-    println!("\n🎉 File operations demo completed!");
-    println!("\n🔒 Security features demonstrated:");
-    println!("   ✅ Path validation and sanitization");
-    println!("   ✅ Directory traversal prevention");
-    println!("   ✅ File extension filtering");
-    println!("   ✅ File size limits");
-    println!("   ✅ Read-only mode support");
+    eprintln!("\n🎉 File operations demo completed!");
+    eprintln!("\n🔒 Security features demonstrated:");
+    eprintln!("   ✅ Path validation and sanitization");
+    eprintln!("   ✅ Directory traversal prevention");
+    eprintln!("   ✅ File extension filtering");
+    eprintln!("   ✅ File size limits");
+    eprintln!("   ✅ Read-only mode support");
 
     Ok(())
 }

--- a/src/examples/example_08_http_client.rs
+++ b/src/examples/example_08_http_client.rs
@@ -384,33 +384,33 @@ impl HttpClientServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("🌐 Starting HTTP Client MCP Server");
-    println!("=================================");
+    eprintln!("🌐 Starting HTTP Client MCP Server");
+    eprintln!("=================================");
 
     // Create config
     let config = HttpClientConfig::default();
 
-    println!("⚙️  HTTP Configuration:");
-    println!("   Timeout: {}s", config.timeout_seconds);
-    println!("   Max response size: {} bytes", config.max_response_size);
-    println!("   Allowed domains: {:?}", config.allowed_domains);
-    println!("   User agent: {}", config.user_agent);
+    eprintln!("⚙️  HTTP Configuration:");
+    eprintln!("   Timeout: {}s", config.timeout_seconds);
+    eprintln!("   Max response size: {} bytes", config.max_response_size);
+    eprintln!("   Allowed domains: {:?}", config.allowed_domains);
+    eprintln!("   User agent: {}", config.user_agent);
 
     // Create server
     let server = HttpClientServer::new(config)?;
 
     // Demo HTTP operations
-    println!("\n🧪 HTTP Client Demo:");
+    eprintln!("\n🧪 HTTP Client Demo:");
 
     // List tools
     let tools = server.list_tools();
-    println!("📋 Available tools ({}):", tools.len());
+    eprintln!("📋 Available tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Test health check
-    println!("\n🏥 Health check test:");
+    eprintln!("\n🏥 Health check test:");
     let health_args = serde_json::json!({
         "url": "https://httpbin.org"
     });
@@ -425,16 +425,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let response_time = result.get("response_time_ms").unwrap_or(&Value::Null);
 
             if accessible {
-                println!("  ✅ httpbin.org is accessible ({}ms)", response_time);
+                eprintln!("  ✅ httpbin.org is accessible ({}ms)", response_time);
             } else {
-                println!("  ❌ httpbin.org is not accessible");
+                eprintln!("  ❌ httpbin.org is not accessible");
             }
         }
-        Err(e) => println!("  ❌ Health check failed: {}", e),
+        Err(e) => eprintln!("  ❌ Health check failed: {}", e),
     }
 
     // Test API call
-    println!("\n🔌 API call test:");
+    eprintln!("\n🔌 API call test:");
     let api_args = serde_json::json!({
         "service": "httpbin",
         "endpoint": "get"
@@ -443,20 +443,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("api_call", api_args).await {
         Ok(result) => {
             if let Ok(response) = serde_json::from_value::<HttpResponse>(result) {
-                println!("  ✅ API call successful:");
-                println!("     Status: {}", response.status);
-                println!(
+                eprintln!("  ✅ API call successful:");
+                eprintln!("     Status: {}", response.status);
+                eprintln!(
                     "     Content-Type: {}",
                     response.content_type.unwrap_or("unknown".to_string())
                 );
-                println!("     Body size: {} bytes", response.body.len());
+                eprintln!("     Body size: {} bytes", response.body.len());
             }
         }
-        Err(e) => println!("  ❌ API call failed: {}", e),
+        Err(e) => eprintln!("  ❌ API call failed: {}", e),
     }
 
     // Test custom HTTP request
-    println!("\n📡 Custom HTTP request test:");
+    eprintln!("\n📡 Custom HTTP request test:");
     let http_args = serde_json::json!({
         "url": "https://jsonplaceholder.typicode.com/posts/1",
         "method": "GET"
@@ -465,27 +465,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("http_request", http_args).await {
         Ok(result) => {
             if let Ok(response) = serde_json::from_value::<HttpResponse>(result) {
-                println!("  ✅ HTTP request successful:");
-                println!("     Status: {}", response.status);
-                println!("     URL: {}", response.url);
+                eprintln!("  ✅ HTTP request successful:");
+                eprintln!("     Status: {}", response.status);
+                eprintln!("     URL: {}", response.url);
 
                 // Try to parse JSON response
                 if let Ok(json) = serde_json::from_str::<Value>(&response.body) {
                     if let Some(title) = json.get("title") {
-                        println!("     Post title: {}", title);
+                        eprintln!("     Post title: {}", title);
                     }
                 }
             }
         }
-        Err(e) => println!("  ❌ HTTP request failed: {}", e),
+        Err(e) => eprintln!("  ❌ HTTP request failed: {}", e),
     }
 
-    println!("\n🎉 HTTP client demo completed!");
-    println!("\n🔒 Security features:");
-    println!("   ✅ Domain allowlisting");
-    println!("   ✅ Response size limits");
-    println!("   ✅ Request timeouts");
-    println!("   ✅ URL validation");
+    eprintln!("\n🎉 HTTP client demo completed!");
+    eprintln!("\n🔒 Security features:");
+    eprintln!("   ✅ Domain allowlisting");
+    eprintln!("   ✅ Response size limits");
+    eprintln!("   ✅ Request timeouts");
+    eprintln!("   ✅ URL validation");
 
     Ok(())
 }

--- a/src/examples/example_09_database.rs
+++ b/src/examples/example_09_database.rs
@@ -168,7 +168,7 @@ impl DatabaseServer {
         .await
         .map_err(|e| format!("Failed to create logs table: {}", e))?;
 
-        println!("✅ Database migrations completed");
+        eprintln!("✅ Database migrations completed");
         Ok(())
     }
 
@@ -552,32 +552,32 @@ impl DatabaseServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("🗄️  Starting Database MCP Server");
-    println!("===============================");
+    eprintln!("🗄️  Starting Database MCP Server");
+    eprintln!("===============================");
 
     // Create config
     let config = DatabaseConfig::default();
 
-    println!("⚙️  Database Configuration:");
-    println!("   Database URL: {}", config.database_url);
-    println!("   Max connections: {}", config.max_connections);
-    println!("   Enable migrations: {}", config.enable_migrations);
+    eprintln!("⚙️  Database Configuration:");
+    eprintln!("   Database URL: {}", config.database_url);
+    eprintln!("   Max connections: {}", config.max_connections);
+    eprintln!("   Enable migrations: {}", config.enable_migrations);
 
     // Create server
     let server = DatabaseServer::new(config).await?;
 
     // Demo database operations
-    println!("\n🧪 Database Operations Demo:");
+    eprintln!("\n🧪 Database Operations Demo:");
 
     // List tools
     let tools = server.list_tools();
-    println!("📋 Available tools ({}):", tools.len());
+    eprintln!("📋 Available tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Create a demo user
-    println!("\n👤 Creating demo user:");
+    eprintln!("\n👤 Creating demo user:");
     let create_args = serde_json::json!({
         "name": "Alice Johnson",
         "email": "alice@example.com",
@@ -587,10 +587,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match server.call_tool("create_user", create_args).await {
         Ok(result) => {
             if let Ok(user) = serde_json::from_value::<User>(result) {
-                println!("  ✅ Created user: {} (ID: {})", user.name, user.id);
+                eprintln!("  ✅ Created user: {} (ID: {})", user.name, user.id);
 
                 // Update the user
-                println!("\n✏️  Updating user:");
+                eprintln!("\n✏️  Updating user:");
                 let update_args = serde_json::json!({
                     "id": user.id,
                     "name": "Alice Smith"
@@ -599,14 +599,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 match server.call_tool("update_user", update_args).await {
                     Ok(updated) => {
                         if let Ok(updated_user) = serde_json::from_value::<User>(updated) {
-                            println!("  ✅ Updated user: {}", updated_user.name);
+                            eprintln!("  ✅ Updated user: {}", updated_user.name);
                         }
                     }
-                    Err(e) => println!("  ❌ Update failed: {}", e),
+                    Err(e) => eprintln!("  ❌ Update failed: {}", e),
                 }
 
                 // Search users
-                println!("\n🔍 Searching users:");
+                eprintln!("\n🔍 Searching users:");
                 let search_args = serde_json::json!({
                     "query": "Alice",
                     "limit": 5
@@ -616,40 +616,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(results) => {
                         let default_count = Value::Number(serde_json::Number::from(0));
                         let count = results.get("count").unwrap_or(&default_count);
-                        println!("  ✅ Found {} users matching 'Alice'", count);
+                        eprintln!("  ✅ Found {} users matching 'Alice'", count);
                     }
-                    Err(e) => println!("  ❌ Search failed: {}", e),
+                    Err(e) => eprintln!("  ❌ Search failed: {}", e),
                 }
             }
         }
-        Err(e) => println!("  ❌ Create user failed: {}", e),
+        Err(e) => eprintln!("  ❌ Create user failed: {}", e),
     }
 
     // Get database stats
-    println!("\n📊 Database statistics:");
+    eprintln!("\n📊 Database statistics:");
     match server
         .call_tool("get_database_stats", serde_json::json!({}))
         .await
     {
         Ok(result) => {
             if let Ok(stats) = serde_json::from_value::<DatabaseStats>(result) {
-                println!("  ✅ Total users: {}", stats.total_users);
-                println!("     Tables: {}", stats.table_count);
-                println!("     Pool size: {}", stats.connection_pool_size);
-                println!("     Active connections: {}", stats.active_connections);
+                eprintln!("  ✅ Total users: {}", stats.total_users);
+                eprintln!("     Tables: {}", stats.table_count);
+                eprintln!("     Pool size: {}", stats.connection_pool_size);
+                eprintln!("     Active connections: {}", stats.active_connections);
             }
         }
-        Err(e) => println!("  ❌ Stats failed: {}", e),
+        Err(e) => eprintln!("  ❌ Stats failed: {}", e),
     }
 
-    println!("\n🎉 Database demo completed!");
-    println!("\n💾 Database features demonstrated:");
-    println!("   ✅ Connection pooling with SQLite");
-    println!("   ✅ Prepared statements for security");
-    println!("   ✅ Database migrations");
-    println!("   ✅ CRUD operations with proper error handling");
-    println!("   ✅ Search and pagination");
-    println!("   ✅ Operation logging and statistics");
+    eprintln!("\n🎉 Database demo completed!");
+    eprintln!("\n💾 Database features demonstrated:");
+    eprintln!("   ✅ Connection pooling with SQLite");
+    eprintln!("   ✅ Prepared statements for security");
+    eprintln!("   ✅ Database migrations");
+    eprintln!("   ✅ CRUD operations with proper error handling");
+    eprintln!("   ✅ Search and pagination");
+    eprintln!("   ✅ Operation logging and statistics");
 
     Ok(())
 }

--- a/src/examples/example_10_streaming.rs
+++ b/src/examples/example_10_streaming.rs
@@ -438,17 +438,17 @@ impl StreamingServer {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    println!("📡 Starting Real-time Streaming MCP Server");
-    println!("==========================================");
+    eprintln!("📡 Starting Real-time Streaming MCP Server");
+    eprintln!("==========================================");
 
     // Create config
     let config = StreamingConfig::default();
 
-    println!("⚙️  Streaming Configuration:");
-    println!("   Max subscribers: {}", config.max_subscribers);
-    println!("   Buffer size: {}", config.buffer_size);
-    println!("   Data interval: {}ms", config.data_generation_interval_ms);
-    println!("   Heartbeat interval: {}ms", config.heartbeat_interval_ms);
+    eprintln!("⚙️  Streaming Configuration:");
+    eprintln!("   Max subscribers: {}", config.max_subscribers);
+    eprintln!("   Buffer size: {}", config.buffer_size);
+    eprintln!("   Data interval: {}ms", config.data_generation_interval_ms);
+    eprintln!("   Heartbeat interval: {}ms", config.heartbeat_interval_ms);
 
     // Create server
     let server = StreamingServer::new(config);
@@ -456,38 +456,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start background streams
     server.start_background_streams();
 
-    println!("\n🧪 Streaming Demo:");
+    eprintln!("\n🧪 Streaming Demo:");
 
     // List tools
     let tools = server.list_tools();
-    println!("📋 Available tools ({}):", tools.len());
+    eprintln!("📋 Available tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Wait a moment for some data to be generated
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
     // Get stream stats
-    println!("\n📊 Stream statistics:");
+    eprintln!("\n📊 Stream statistics:");
     match server
         .call_tool("get_stream_stats", serde_json::json!({}))
         .await
     {
         Ok(result) => {
             if let Ok(stats) = serde_json::from_value::<StreamStats>(result) {
-                println!("  ✅ Active streams: {}", stats.active_streams);
-                println!("     Total messages: {}", stats.total_messages);
-                println!("     Subscribers: {}", stats.subscriber_count);
-                println!("     Buffer utilization: {:.1}%", stats.buffer_utilization);
-                println!("     Uptime: {}s", stats.uptime_seconds);
+                eprintln!("  ✅ Active streams: {}", stats.active_streams);
+                eprintln!("     Total messages: {}", stats.total_messages);
+                eprintln!("     Subscribers: {}", stats.subscriber_count);
+                eprintln!("     Buffer utilization: {:.1}%", stats.buffer_utilization);
+                eprintln!("     Uptime: {}s", stats.uptime_seconds);
             }
         }
-        Err(e) => println!("  ❌ Stats failed: {}", e),
+        Err(e) => eprintln!("  ❌ Stats failed: {}", e),
     }
 
     // Get recent messages
-    println!("\n📨 Recent messages:");
+    eprintln!("\n📨 Recent messages:");
     match server
         .call_tool(
             "get_recent_messages",
@@ -501,12 +501,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let default_count = Value::Number(serde_json::Number::from(0));
             let count = result.get("count").unwrap_or(&default_count);
-            println!("  ✅ Retrieved {} recent metrics messages", count);
+            eprintln!("  ✅ Retrieved {} recent metrics messages", count);
 
             if let Some(messages) = result.get("messages").and_then(|m| m.as_array()) {
                 for message in messages.iter().take(2) {
                     if let Some(id) = message.get("id") {
-                        println!(
+                        eprintln!(
                             "     Message {}: {}",
                             id,
                             message.get("message_type").unwrap_or(&Value::Null)
@@ -515,11 +515,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        Err(e) => println!("  ❌ Get messages failed: {}", e),
+        Err(e) => eprintln!("  ❌ Get messages failed: {}", e),
     }
 
     // Send custom message
-    println!("\n📤 Sending custom message:");
+    eprintln!("\n📤 Sending custom message:");
     match server
         .call_tool(
             "send_custom_message",
@@ -533,16 +533,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let message_id = result.get("message_id").unwrap_or(&Value::Null);
             let subscriber_count = result.get("subscriber_count").unwrap_or(&Value::Null);
-            println!(
+            eprintln!(
                 "  ✅ Sent message {} to {} subscribers",
                 message_id, subscriber_count
             );
         }
-        Err(e) => println!("  ❌ Send message failed: {}", e),
+        Err(e) => eprintln!("  ❌ Send message failed: {}", e),
     }
 
     // Start a temporary stream
-    println!("\n🎬 Starting demo stream:");
+    eprintln!("\n🎬 Starting demo stream:");
     match server
         .call_tool(
             "start_stream",
@@ -555,7 +555,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
     {
         Ok(result) => {
-            println!(
+            eprintln!(
                 "  ✅ Started event stream: {}",
                 result.get("message").unwrap_or(&Value::Null)
             );
@@ -569,21 +569,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await
             {
                 if let Ok(stats) = serde_json::from_value::<StreamStats>(final_stats) {
-                    println!("  📈 Final message count: {}", stats.total_messages);
+                    eprintln!("  📈 Final message count: {}", stats.total_messages);
                 }
             }
         }
-        Err(e) => println!("  ❌ Start stream failed: {}", e),
+        Err(e) => eprintln!("  ❌ Start stream failed: {}", e),
     }
 
-    println!("\n🎉 Streaming demo completed!");
-    println!("\n🌊 Streaming features demonstrated:");
-    println!("   ✅ Real-time message broadcasting");
-    println!("   ✅ Multiple concurrent streams");
-    println!("   ✅ Async channel-based communication");
-    println!("   ✅ Subscriber management");
-    println!("   ✅ Message filtering and retrieval");
-    println!("   ✅ Stream statistics and monitoring");
+    eprintln!("\n🎉 Streaming demo completed!");
+    eprintln!("\n🌊 Streaming features demonstrated:");
+    eprintln!("   ✅ Real-time message broadcasting");
+    eprintln!("   ✅ Multiple concurrent streams");
+    eprintln!("   ✅ Async channel-based communication");
+    eprintln!("   ✅ Subscriber management");
+    eprintln!("   ✅ Message filtering and retrieval");
+    eprintln!("   ✅ Stream statistics and monitoring");
 
     Ok(())
 }

--- a/src/examples/example_11_monitoring.rs
+++ b/src/examples/example_11_monitoring.rs
@@ -684,36 +684,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging for observability
     tracing_subscriber::fmt::init();
 
-    println!("🚀 Starting Monitoring and Metrics Server");
-    println!("==========================================");
+    eprintln!("🚀 Starting Monitoring and Metrics Server");
+    eprintln!("==========================================");
 
     let server = MonitoringServer::new();
 
-    println!("\n🧪 Monitoring and Metrics Demo:");
+    eprintln!("\n🧪 Monitoring and Metrics Demo:");
 
     // List available tools
     let tools = server.list_tools();
-    println!("📋 Available monitoring tools ({}):", tools.len());
+    eprintln!("📋 Available monitoring tools ({}):", tools.len());
     for tool in &tools {
-        println!("  - {}: {}", tool.name, tool.description);
+        eprintln!("  - {}: {}", tool.name, tool.description);
     }
 
     // Demonstrate metrics collection
-    println!("\n📊 Collecting current system metrics:");
+    eprintln!("\n📊 Collecting current system metrics:");
     match server
         .call_tool("get_current_metrics", serde_json::json!({}))
         .await
     {
         Ok(result) => {
             let metrics: SystemMetrics = serde_json::from_value(result).unwrap();
-            println!("  ✅ Metrics collected successfully");
-            println!("     CPU Usage: {:.1}%", metrics.cpu_usage_percent);
-            println!("     Memory Usage: {:.1}%", metrics.memory_usage_percent);
-            println!("     Disk Usage: {:.1}%", metrics.disk_usage_percent);
-            println!("     Active Connections: {}", metrics.active_connections);
-            println!("     Uptime: {} seconds", metrics.uptime_seconds);
+            eprintln!("  ✅ Metrics collected successfully");
+            eprintln!("     CPU Usage: {:.1}%", metrics.cpu_usage_percent);
+            eprintln!("     Memory Usage: {:.1}%", metrics.memory_usage_percent);
+            eprintln!("     Disk Usage: {:.1}%", metrics.disk_usage_percent);
+            eprintln!("     Active Connections: {}", metrics.active_connections);
+            eprintln!("     Uptime: {} seconds", metrics.uptime_seconds);
         }
-        Err(e) => println!("  ❌ Metrics collection failed: {}", e),
+        Err(e) => eprintln!("  ❌ Metrics collection failed: {}", e),
     }
 
     // Wait a moment and collect metrics again to build history
@@ -723,7 +723,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await;
 
     // Demonstrate metrics history
-    println!("\n📈 Retrieving metrics history:");
+    eprintln!("\n📈 Retrieving metrics history:");
     match server
         .call_tool("get_metrics_history", serde_json::json!({"limit": 5}))
         .await
@@ -731,14 +731,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let history_data: Value = result;
             let total_records = history_data.get("total_records").unwrap_or(&Value::Null);
-            println!("  ✅ Retrieved metrics history");
-            println!("     Total records: {}", total_records);
+            eprintln!("  ✅ Retrieved metrics history");
+            eprintln!("     Total records: {}", total_records);
         }
-        Err(e) => println!("  ❌ History retrieval failed: {}", e),
+        Err(e) => eprintln!("  ❌ History retrieval failed: {}", e),
     }
 
     // Demonstrate health checks
-    println!("\n🏥 Performing health checks:");
+    eprintln!("\n🏥 Performing health checks:");
     match server
         .call_tool(
             "perform_health_check",
@@ -749,8 +749,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let health_data: Value = result;
             let checks_performed = health_data.get("checks_performed").unwrap_or(&Value::Null);
-            println!("  ✅ Health checks completed");
-            println!("     Checks performed: {}", checks_performed);
+            eprintln!("  ✅ Health checks completed");
+            eprintln!("     Checks performed: {}", checks_performed);
 
             if let Some(results) = health_data.get("results") {
                 if let Some(results_array) = results.as_array() {
@@ -758,7 +758,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if let Ok(check) =
                             serde_json::from_value::<HealthCheckResult>(result.clone())
                         {
-                            println!(
+                            eprintln!(
                                 "     - {}: {} ({}ms)",
                                 check.service_name, check.status, check.response_time_ms
                             );
@@ -767,11 +767,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        Err(e) => println!("  ❌ Health checks failed: {}", e),
+        Err(e) => eprintln!("  ❌ Health checks failed: {}", e),
     }
 
     // Demonstrate alert management
-    println!("\n🚨 Checking active alerts:");
+    eprintln!("\n🚨 Checking active alerts:");
     match server
         .call_tool("get_active_alerts", serde_json::json!({}))
         .await
@@ -779,14 +779,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let alerts_data: Value = result;
             let total_alerts = alerts_data.get("total_alerts").unwrap_or(&Value::Null);
-            println!("  ✅ Alert check completed");
-            println!("     Active alerts: {}", total_alerts);
+            eprintln!("  ✅ Alert check completed");
+            eprintln!("     Active alerts: {}", total_alerts);
         }
-        Err(e) => println!("  ❌ Alert check failed: {}", e),
+        Err(e) => eprintln!("  ❌ Alert check failed: {}", e),
     }
 
     // Demonstrate threshold configuration
-    println!("\n⚙️  Configuring alert thresholds:");
+    eprintln!("\n⚙️  Configuring alert thresholds:");
     let threshold_config = serde_json::json!({
         "metric_name": "cpu_usage_percent",
         "threshold": 75.0,
@@ -800,26 +800,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(result) => {
             let config_data: Value = result;
             let success = config_data.get("success").unwrap_or(&Value::Null);
-            println!("  ✅ Threshold configuration: {}", success);
+            eprintln!("  ✅ Threshold configuration: {}", success);
         }
-        Err(e) => println!("  ❌ Threshold configuration failed: {}", e),
+        Err(e) => eprintln!("  ❌ Threshold configuration failed: {}", e),
     }
 
-    println!("\n🎉 Monitoring and Metrics demo completed!");
-    println!("\n✨ This is example 11 of 20 progressive MCP examples.");
-    println!("   This example demonstrates comprehensive monitoring patterns");
-    println!("   essential for production systems including:");
-    println!("   - Real-time metrics collection and storage");
-    println!("   - Health check orchestration and reporting");
-    println!("   - Threshold-based alerting and notification");
-    println!("   - Historical data management and trend analysis");
-    println!("   - Configurable monitoring parameters");
-    println!("\n🔧 Key production monitoring concepts covered:");
-    println!("   - Circular buffer for metrics history management");
-    println!("   - Thread-safe data structures for concurrent access");
-    println!("   - Realistic simulation of system resource monitoring");
-    println!("   - Alert lifecycle management (creation, filtering, clearing)");
-    println!("   - Extensible architecture for additional monitoring tools");
+    eprintln!("\n🎉 Monitoring and Metrics demo completed!");
+    eprintln!("\n✨ This is example 11 of 20 progressive MCP examples.");
+    eprintln!("   This example demonstrates comprehensive monitoring patterns");
+    eprintln!("   essential for production systems including:");
+    eprintln!("   - Real-time metrics collection and storage");
+    eprintln!("   - Health check orchestration and reporting");
+    eprintln!("   - Threshold-based alerting and notification");
+    eprintln!("   - Historical data management and trend analysis");
+    eprintln!("   - Configurable monitoring parameters");
+    eprintln!("\n🔧 Key production monitoring concepts covered:");
+    eprintln!("   - Circular buffer for metrics history management");
+    eprintln!("   - Thread-safe data structures for concurrent access");
+    eprintln!("   - Realistic simulation of system resource monitoring");
+    eprintln!("   - Alert lifecycle management (creation, filtering, clearing)");
+    eprintln!("   - Extensible architecture for additional monitoring tools");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
Replace println\! with eprintln\! for startup messages and demo output in all MCP server examples to comply with the stdio transport specification.

Writing non-JSON-RPC messages to stdout makes the servers difficult to work with since clients expect only valid MCP messages on stdout. The [MCP stdio transport specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio) requires that servers write only valid MCP messages to stdout.

Updated all 11 server examples to use eprintln\! instead of println\! for informational output.

## Test plan
- [x] Builds successfully with `cargo build --release`
- [x] All servers now comply with MCP stdio transport specification